### PR TITLE
Changes needed for ReJSON multi values and multi paths #477

### DIFF
--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -533,6 +533,7 @@ where
             );
         }
 
+        assert!(result.is_empty());
         // The returned value vector is ordered according to the returned path vector
         found_result.drain(..).for_each(|t|{result.push(t);});
 


### PR DESCRIPTION
Needed for [ReJSON multi values and multi paths #477](https://github.com/RedisJSON/RedisJSON/pull/477)

This change is needed to also get the values, in addition to the paths, from `compute_paths`